### PR TITLE
docs: use shallow clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Welcome to PheloiVim, a Neovim configuration tailored to enhance your editing ex
 1. **Clone the Repository**: Clone this repository to your local machine:
 
 ```bash
-git clone https://github.com/2giosangmitom/PheloiVim.git ~/.config/nvim
+git clone --depth 1 https://github.com/2giosangmitom/PheloiVim.git ~/.config/nvim
 ```
 
 2. **Explore**: Take some time to explore the included plugins and their features. Refer to their respective documentation for detailed usage instructions.


### PR DESCRIPTION
When cloning repositories for development or deployment purposes, consider using shallow clones (`--depth`) to fetch only the latest commits without downloading the entire history.